### PR TITLE
chore: move chip to standalone component for better reusability

### DIFF
--- a/app/resources/views/components/chip.blade.php
+++ b/app/resources/views/components/chip.blade.php
@@ -1,0 +1,22 @@
+<{{ $component ?? 'span' }}
+    {{
+        $attributes
+            ->class([
+                'bg-neutral-50',
+                'border',
+                'border-neutral-500',
+                'dark:bg-neutral-700',
+                'dark:hover:border-neutral-400',
+                'dark:hover:bg-neutral-600',
+                'hover:bg-neutral-200',
+                'hover:border-neutral-600',
+                'px-2',
+                'py-1',
+                'rounded-full',
+                'text-xs',
+                'w-fit',
+            ])
+    }}
+>
+    {{ $slot }}
+</{{ $component ?? 'span' }}>

--- a/app/resources/views/components/tag.blade.php
+++ b/app/resources/views/components/tag.blade.php
@@ -1,22 +1,6 @@
-<a
-    {{
-        $attributes
-            ->class([
-                'bg-neutral-50',
-                'border',
-                'border-neutral-500',
-                'dark:bg-neutral-700',
-                'dark:hover:border-neutral-400',
-                'dark:hover:bg-neutral-600',
-                'hover:bg-neutral-200',
-                'hover:border-neutral-600',
-                'px-2',
-                'py-1',
-                'rounded-full',
-                'text-xs',
-            ])
-    }}
+<x-chip
+    {{ $attributes }}
     href="{{ route('search', ['tag' => [$tag->id]]) }}"
 >
     {{ __("tag.{$tag->title}") }}{{ $slot }}
-</a>
+</x-chip>


### PR DESCRIPTION
There are use-cases above tags which could also use a chip. For this reason, move chip to its own component,
and implement tag with the new chip component.